### PR TITLE
Add site functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <h1>✨ Self-Care Center ✨</h1>
     <h2> Which type of message?</h2>
     <section class="message-selector-box">
-      <!-- Buttons & Text need to be in div to display as inline-block. Receive button is left out because it should be display as block on separate line -->
       <div class="type-selection">
         <button type="button" class="affirmation-button js-affirmation"></button>
         <p class="affirmation-text">affirmation</p>
@@ -19,8 +18,8 @@
       </div>
     </section>
     <section class="message-box js-message">
-      <img class="js-person-icon" url="./assets/meditate.png" alt="bell person" srcset="./assets/meditate.svg">
-      <p class="message"></p>
+      <img class="person-icon js-person-icon" url="./assets/meditate.png" alt="bell person" srcset="./assets/meditate.svg">
+      <!-- <p class="message js-message"></p> -->
     </section>
     <script type="text/javascript" src="main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,15 @@
+// Query Selectors
+var affirmationButton = document.querySelector('.js-affirmation');
+var mantraButton = document.querySelector('.js-mantra');
+var receiveMessage = document.querySelector('.js-receive');
+var personIcon = document.querySelector('.js-person-icon');
+var messageBox = document.querySelector('.message-box');
+
+// Event Listeners
+affirmationButton.addEventListener('click', selectAffirmation);
+mantraButton.addEventListener('click', selectMantra);
+receiveMessage.addEventListener('click', displayMessage);
+
 // Global Variables
 var affirmations = [
   'I forgive myself and set myself free.',
@@ -31,3 +43,31 @@ var mantras = [
   'Onward and upward.',
   'I am the sky, the rest is weather.'
 ];
+
+// Functions & Event Handlers
+function getRandomMessage(type) {
+  var index = Math.floor(Math.random() * type.length);
+  return type[index];
+}
+
+function selectAffirmation() {
+  if (!mantraButton.classList.contains('selected')) {
+    affirmationButton.classList.add('selected');
+  }
+}
+
+function selectMantra() {
+  if (!affirmationButton.classList.contains('selected')) {
+    mantraButton.classList.add('selected');
+  }
+}
+
+function displayMessage() {
+  // personIcon.classList.add('hidden');
+  if (affirmationButton.classList.contains('selected')) {
+    var randomMessage = getRandomMessage(affirmations);
+  } else if (mantraButton.classList.contains('selected')) {
+    var randomMessage = getRandomMessage(mantras);
+  }
+  messageBox.innerHTML = `<p>${randomMessage}</p>`;
+}

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,7 @@ html {
 
 body {
   padding-top: 30px;
+  font-size: 20px;
 }
 
 h1 {
@@ -30,32 +31,39 @@ section {
   padding: 3% 0;
 }
 
-/* Round buttons */
 button {
   height: 16px;
   border-radius: 50%;
 }
 
-/* Responsive cursor */
 button:hover {
   cursor: pointer;
 }
 
+p {
+  color: #000000;
+}
+
+.selected {
+  background-color: #0175FF;
+  border: 3px solid white;
+  box-shadow: 0 0 3px 1px #0175FF;
+}
+
+.hidden {
+  display: none!important;
+}
+
 /* ~~~~~ MESSAGE TYPE SELECTION SECTION ~~~~~ */
 .message-selector-box {
-  /* Changes dynamically with browser window */
-  width: 33%;
+  width: 40%;
   margin-bottom: 100px;
-  font-size: 18px;
 }
 
 .message-selector-box p {
-  color: #000000;
   font-style: italic;
   margin-left: 7px;
   margin-bottom: 25px;
-  /* So that p elements appear next to buttons.
-  Perhaps we don't also need it on buttons because of cascading? Or- they can be block so long as there are inline elements between? */
   display: inline-block;
 }
 
@@ -63,43 +71,30 @@ button:hover {
   margin-right: 120px;
 }
 
-/* Class that will be used in main.js to highlight round buttons */
-.selected {
-  background-color: #0175FF;
-  border: 3px solid white;
-  box-shadow: 0 0 3px 1px #0175FF;
-}
-
 .receive-message-button {
   background-color: #134d71;
-  border-radius: 10px;
+  border-radius: 7px;
   border: 0;
-  font-size: larger;
-  /* overrides general button element height of 16px */
+  font-size: 22px;
   height: auto;
   padding: 7px 40px;
   display: block;
 }
 
-/* Responsive mouseover */
 .receive-message-button:hover {
   background-color: #78a7c6;
 }
 
 /* ~~~~~ MESSAGE DISPLAY SECTION ~~~~~ */
 .message-box {
+  height: 200px;
   width: 60%;
+  color: #000000;
+  font-size: 26px;
+  display: flex;
+  justify-content: center;
 }
 
-.message-box img {
-  width: 15%;
+.person-icon {
+  margin: 0;
 }
-
-/* font-family: 'Quicksand', sans-serif;
-COLORS
-light-yellow - #f7e4bf;
-light-blue - #78a7c6;
-dark-blue - #134d71;
-white - #ffffff;
-black - #000000;
-*/


### PR DESCRIPTION
Users can now select affirmation or mantra and click the 'Receive Message' button to see a randomly generated message in the chosen category. They can continuously click 'Receive Message' to view new random instances.

Next steps:  
* Eliminate need to refresh whole page to switch selected message type. Implement some kind of toggle feature so users can go back and forth with their selection.
* Enlarge image in message display box. Struggled through getting both the image and message to center while maintaining same height of white box during the switch. I don't quite understand yet why the current img declaration block works (commented out lines in Dev Tools and the parent display: flex; and img margin: 0; make the resize happen). It is dynamic based on browser window size- which I like -but becomes too small with large window.