### PR TITLE
Add no repeat messages functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
       <h3> Which type of message?</h3>
       <section class="message-selector-box">
           <form>
-            <div class="affirmation-selection">
+            <div>
               <input type="radio" id="affirmation" name="messageType" value="affirmation">
               <label for="affirmation">affirmation</label>
             </div>
-            <div class="mantra-selection">
+            <div>
               <input type="radio" id="mantra" name="messageType" value="mantra">
               <label for="affirmation">mantra</label>
             </div>
@@ -38,6 +38,7 @@
     <article class="fav-messages-grid" id="js-fav-msg-grid">
     </article>
     <button type="button" id="back-to-main">Back To Main</button>
+    <h5>(double click to delete)</h5>
   </section>
     <script type="text/javascript" src="main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -22,6 +22,13 @@ favMsgGrid.addEventListener('dblclick', deleteMessage);
 
 // Global Variables
 var affirmations = [
+  // '1',
+  // '2',
+  // '3',
+  // '4',
+  // '5',
+  // '6',
+  // '7',
   'I forgive myself and set myself free.',
   'I believe I can be all that I want to be.',
   'I am in the process of becoming the best version of myself.',
@@ -54,7 +61,8 @@ var mantras = [
   'I am the sky, the rest is weather.'
 ];
 var favoritedMessages = [];
-var seenMessages = [];
+var seenAffirmations = [];
+var seenMantras = [];
 var currentMessage;
 
 // Functions & Event Handlers
@@ -83,18 +91,44 @@ function getRandomIndex(messageType) {
 function generateMessage() {
   if (affirmationButton.checked) {
     currentMessage = getRandomIndex(affirmations);
+    noRepeats(affirmations, seenAffirmations);
   } else if (mantraButton.checked){
     currentMessage = getRandomIndex(mantras);
+    noRepeats(mantras, seenMantras)
   }
   return currentMessage;
 }
 
+function noRepeats(messageType, seenArray) {
+  if (seenArray.length !== messageType.length) {
+    if (seenArray.includes(currentMessage)) {
+      generateMessage();
+    } else {
+      seenArray.push(currentMessage);
+    }
+  } else {
+    currentMessage = resetNoRepeats(messageType);
+  }
+}
+
+function resetNoRepeats(messageType) {
+  if (messageType === affirmations) {
+    seenAffirmations = [currentMessage];
+    var viewedAll = 'affirmations';
+  } else {
+    seenMantras = [currentMessage];
+    var viewedAll = 'mantras';
+  }
+  likeButton.classList.add('hidden');
+  return `You have viewed all ${viewedAll}. You will now start seeing repeats.`;
+}
+
 function displayMessage() {
+  enableFavorite();
+  changeHidden([personImage], [likeButton, messageDisplay]);
   message.innerText = generateMessage();
-  changeHidden([personImage], [messageDisplay]);
   displayClearButton();
   displayViewFavsButton();
-  enableFavorite();
   likeButton.classList.remove('pink');
   if (favoritedMessages.includes(currentMessage)) {
     likeButton.classList.add('pink');

--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,10 @@ button {
   padding: .3em 2em;
 }
 
+button:hover {
+  background-color: #78a7c6;
+}
+
 input {
   border: 0px;
   height: 1.6em;
@@ -58,10 +62,6 @@ input:hover,
 button:hover,
 i:hover {
   cursor: pointer;
-}
-
-button:hover {
-  background-color: #78a7c6;
 }
 
 p,
@@ -105,7 +105,6 @@ label {
 }
 
 .person-img {
-  /* margin: auto; */
   height: 70%;
   min-width: 20%;
 }
@@ -122,7 +121,7 @@ label {
 /* ~~~~~ FAV MESSAGE SECTION ~~~~~ */
 .fav-messages-grid {
   display: grid;
-  grid-template-rows: repeat();
+  grid-template-rows: repeat;
   grid-gap: 20px;
 }
 


### PR DESCRIPTION
Added complexity to the message generation functions so that user does not see repeats until all affirmations or mantras have cycled through. A message then shows that alerts the user that they'll start seeing repeats. When that message shows, the like button disappears so that users cannot add it to their favorited messages.

Next steps: 
• Final refactor
• Create README